### PR TITLE
Add --allow-no-migration to deploy:pimcore:migrate

### DIFF
--- a/recipes/pimcore.php
+++ b/recipes/pimcore.php
@@ -25,7 +25,7 @@ task('deploy:pimcore:migrate:core', function() {
 });
 
 task('deploy:pimcore:migrate', function () {
-    run('{{bin/php}} {{bin/console}} pimcore:migrations:migrate --allow-no-migration');
+    run('{{bin/php}} {{bin/console}} pimcore:migrations:migrate --allow-no-migration -n');
 });
 
 task('deploy:pimcore:merge:shared', function () {

--- a/recipes/pimcore.php
+++ b/recipes/pimcore.php
@@ -25,7 +25,7 @@ task('deploy:pimcore:migrate:core', function() {
 });
 
 task('deploy:pimcore:migrate', function () {
-    run('{{bin/php}} {{bin/console}} pimcore:migrations:migrate');
+    run('{{bin/php}} {{bin/console}} pimcore:migrations:migrate --allow-no-migration');
 });
 
 task('deploy:pimcore:merge:shared', function () {


### PR DESCRIPTION
The deploy shouldn't fail if there are no migrations to execute.