### PR TITLE
Make pimcore classes-rebuild non interactive

### DIFF
--- a/recipes/pimcore.php
+++ b/recipes/pimcore.php
@@ -17,7 +17,7 @@ task('deploy:pimcore:install-classes', function () {
 });
 
 task('deploy:pimcore:rebuild-classes', function () {
-    run('{{bin/php}} {{bin/console}} pimcore:deployment:classes-rebuild -c -d');
+    run('{{bin/php}} {{bin/console}} pimcore:deployment:classes-rebuild -c -d -n');
 });
 
 task('deploy:pimcore:migrate:core', function() {


### PR DESCRIPTION
Pimcore in at least version 6.5 is more often asking for confirmation, that caused errors.